### PR TITLE
Proposed solution to issue #18, adding overbrace and underbrace

### DIFF
--- a/asciimath-based/ASCIIMath2TeX.php
+++ b/asciimath-based/ASCIIMath2TeX.php
@@ -266,6 +266,8 @@ array( 'input'=>'tilde', 'unary'=>TRUE, 'acc'=>TRUE),
 array( 'input'=>'dot', 'unary'=>TRUE, 'acc'=>TRUE),
 array( 'input'=>'ddot', 'unary'=>TRUE, 'acc'=>TRUE),
 array( 'input'=>'ul', 'tex'=>'underline', 'unary'=>TRUE, 'acc'=>TRUE),
+array( 'input'=>'ubrace', 'tex'=>'underbrace', 'unary'=>TRUE, 'acc'=>TRUE),
+array( 'input'=>'obrace', 'tex'=>'overbrace', 'unary'=>TRUE, 'acc'=>TRUE),
 array( 'input'=>'text', 'text'=>TRUE),
 array( 'input'=>'mbox', 'text'=>TRUE),
 array( 'input'=>'"', 'text'=>TRUE),
@@ -564,7 +566,8 @@ function AMTparseSexpr($str) {
 		} else if ($symbol['input']=='abs') {
 			return array('{\\left|'.$result[0].'\\right|}',$result[1]);
 		} else if (isset($symbol['acc'])) {
-			return array('{'.$this->AMTgetTeXsymbol($symbol).'{'.$result[0].'}}',$result[1]);
+			//return array('{'.$this->AMTgetTeXsymbol($symbol).'{'.$result[0].'}}',$result[1]);
+			return array($this->AMTgetTeXsymbol($symbol).'{'.$result[0].'}',$result[1]);
 		} else {
 			return array('{'.$this->AMTgetTeXsymbol($symbol).'{'.$result[0].'}}',$result[1]);
 		}
@@ -657,7 +660,8 @@ function AMTparseIexpr($str) {
 				$node .= '_{'.$result[0].'}';
 			}
 		} else {
-			$node = '{'.$node.'}^{'.$result[0].'}';
+			//$node = '{'.$node.'}^{'.$result[0].'}';
+			$node = $node.'^{'.$result[0].'}';
 		}
 	}
 	

--- a/asciimath-based/ASCIIMathTeXImg.js
+++ b/asciimath-based/ASCIIMathTeXImg.js
@@ -289,6 +289,8 @@ AMsqrt, AMroot, AMfrac, AMdiv, AMover, AMsub, AMsup,
 {input:"dot", tag:"mover", output:".",      tex:null, ttype:UNARY, acc:true},
 {input:"ddot", tag:"mover", output:"..",    tex:null, ttype:UNARY, acc:true},
 {input:"ul", tag:"munder", output:"\u0332", tex:"underline", ttype:UNARY, acc:true},
+{input:"ubrace", tag:"munder", output:"\u23DF", tex:"underbrace", ttype:UNARY, acc:true},
+{input:"obrace", tag:"mover", output:"\u23DE", tex:"overbrace", ttype:UNARY, acc:true},
 AMtext, AMmbox, AMquote,
 //{input:"var", tag:"mstyle", atname:"fontstyle", atval:"italic", output:"var", tex:null, ttype:UNARY},
 {input:"color", tag:"mstyle", ttype:BINARY},
@@ -316,9 +318,11 @@ var AMnames = []; //list of input symbols
 function AMinitSymbols() {
   var texsymbols = [], i;
   for (i=0; i<AMsymbols.length; i++)
-    if (AMsymbols[i].tex && !(typeof AMsymbols[i].notexcopy == "boolean" && AMsymbols[i].notexcopy)) 
-      texsymbols[texsymbols.length] = {input:AMsymbols[i].tex, 
-        tag:AMsymbols[i].tag, output:AMsymbols[i].output, ttype:AMsymbols[i].ttype};
+    if (AMsymbols[i].tex && !(typeof AMsymbols[i].notexcopy == "boolean" && AMsymbols[i].notexcopy)) {
+       texsymbols[texsymbols.length] = {input:AMsymbols[i].tex, 
+        tag:AMsymbols[i].tag, output:AMsymbols[i].output, ttype:AMsymbols[i].ttype,
+        acc:(AMsymbols[i].acc||false)};
+    }
   AMsymbols = AMsymbols.concat(texsymbols);
   AMsymbols.sort(compareNames);
   for (i=0; i<AMsymbols.length; i++) AMnames[i] = AMsymbols[i].input;
@@ -557,7 +561,8 @@ function AMTparseSexpr(str) { //parses str and returns [node,tailstr]
       } else if (symbol.input == "abs") {           // abs
 	      return ['{\\left|'+result[0]+'\\right|}',result[1]];
       } else if (typeof symbol.acc == "boolean" && symbol.acc) {   // accent
-	      return ['{'+AMTgetTeXsymbol(symbol)+'{'+result[0]+'}}',result[1]];
+	      //return ['{'+AMTgetTeXsymbol(symbol)+'{'+result[0]+'}}',result[1]];
+	      return [AMTgetTeXsymbol(symbol)+'{'+result[0]+'}',result[1]];
       } else {                        // font change command  
 	    return ['{'+AMTgetTeXsymbol(symbol)+'{'+result[0]+'}}',result[1]];
       }
@@ -632,7 +637,6 @@ function AMTparseIexpr(str) {
 //    if (symbol.input == "/") AMTremoveBrackets(node);
     if (symbol.input == "_") {
       sym2 = AMgetSymbol(str);
-      underover = (sym1.ttype == UNDEROVER);
       if (sym2.input == "^") {
         str = AMremoveCharsAndBlanks(str,sym2.input.length);
         var res2 = AMTparseSexpr(str);
@@ -646,7 +650,8 @@ function AMTparseIexpr(str) {
         node += '_{'+result[0]+'}';
       }
     } else { //must be ^
-      node = '{'+node+'}^{'+result[0]+'}';
+      //node = '{'+node+'}^{'+result[0]+'}';
+      node = node+'^{'+result[0]+'}';
     }
   } 
   

--- a/test/index.html
+++ b/test/index.html
@@ -165,6 +165,11 @@ but decimal numbers are parsed with possible sign</td>
 <td><b>\`</b>color(red)(x^2)+3x+color(green)(4)<b>\`</b></td>
 <td>color</td>
 </tr>
+<tr>
+<td>`underbrace(1+2+3+4)_("4 terms") - obrace(2+3)^(n)`</td>
+<td><b>\`</b>underbrace(1+2+3+4)_("4 terms") - obrace(2+3)^(n)<b>\`</b></td>
+<td>under and over braces</td>
+</tr>
 </table>
 
 <p>


### PR DESCRIPTION
In order to get ubrace(A)_(B) and obrace(A)^(B) to display right, I needed to add a new token type that acted as both UNARY and UNDEROVER.  I also had to adjust AMparseIexpr to look for UNDEROVER in S^S type expressions. This is a proposed fix for issue #18 
