### PR TITLE
Replace \matrix with \begin{matrix} ... \end{matrix}

### DIFF
--- a/asciimath-based/ASCIIMathTeXImg.js
+++ b/asciimath-based/ASCIIMathTeXImg.js
@@ -837,7 +837,7 @@ function AMTparseExpr(str,rightbracket) {
 					}
 				}
 				if (columnaligns.indexOf("|")==-1) {
-					mxout = "\\matrix{"+mxout+"}";
+					mxout = "\\begin{matrix}"+mxout+"\\end{matrix}";
 				} else {
 					mxout = "\\begin{array}{"+columnaligns+"} "+mxout+"\\end{array}";
 				}


### PR DESCRIPTION
We should use `\begin{matrix}...\end{matrix}` instead of `\matrix` in LaTeX.

See also:
https://tex.stackexchange.com/questions/26434/where-is-the-matrix-command