### PR TITLE
Clarify how to fix matrices when decimalsign set to ","

### DIFF
--- a/ASCIIMathML.js
+++ b/ASCIIMathML.js
@@ -49,7 +49,7 @@ var translateOnLoad = true;    // set to false to do call translators from js
 var translateASCIIMath = true; // false to preserve `..`
 var displaystyle = true;      // puts limits above and below large operators
 var showasciiformulaonhover = true; // helps students learn ASCIIMath
-var decimalsign = ".";        // change to "," if you like, beware of `(1,2)`!
+var decimalsign = ".";        // if "," then matrix `(1, 2)` not `(1,2)`
 var AMdelimiter1 = "`", AMescape1 = "\\\\`"; // can use other characters
 var AMdocumentId = "wikitext" // PmWiki element containing math (default=body)
 var fixphi = true;  		//false to return to legacy phi/varphi mapping

--- a/ASCIIMathML.js
+++ b/ASCIIMathML.js
@@ -49,7 +49,8 @@ var translateOnLoad = true;    // set to false to do call translators from js
 var translateASCIIMath = true; // false to preserve `..`
 var displaystyle = true;      // puts limits above and below large operators
 var showasciiformulaonhover = true; // helps students learn ASCIIMath
-var decimalsign = ".";        // if "," then matrix `(1, 2)` not `(1,2)`
+var decimalsign = ".";        // if "," then when writing lists or matrices put
+			      //a space after the "," like `(1, 2)` not `(1,2)`
 var AMdelimiter1 = "`", AMescape1 = "\\\\`"; // can use other characters
 var AMdocumentId = "wikitext" // PmWiki element containing math (default=body)
 var fixphi = true;  		//false to return to legacy phi/varphi mapping


### PR DESCRIPTION
Current comment states:

https://github.com/asciimath/asciimathml/blob/58f8b36c32f90470286c183a9f7be766342f19b1/ASCIIMathML.js#L52

It just says to beware, not what to do. I just spent a good while searching the internet for what to do with matrices when `decimalsign` is set to `","`.

Finally, I stumbled upon the [documentation for `decimalsign`](http://docs.mathjax.org/en/latest/options/input-processors/AsciiMath.html), but it would be nice if the comment right in the code would already reveal to the user what to do. So that you can fix your matrices faster and even without internet or access to the docs.