### PR TITLE
Make ASCIIMathTeXImg.js UMD compatible and export as NodeJS package

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,18 @@ simple calculator-style math expressions on a webpage to MathML.
 The resulting page can be displayed with any browser that can render MathML.
 Currently that includes any recent version of Firefox (3+).
 
+
+NodeJS/CommonJS/Webpack Usage
+-----------------------------
+
+```js
+// You can convert ASCIIMath to LaTeX using NodeJS/CommonJS/Webpack!
+const am = require("asciimath")
+am.parse("a / b")  // Returns equivalent latex '\\frac{{a}}{{b}}'
+
+// Changing decimal sign
+// (only relevant property from config, everything else relates to DOM)
+am.parse("1,2/3") // Parsed as two numbers '{1},\\frac{{2}}{{3}}', i.e. 1, 2/3
+am.config.decimalsign = ","
+am.parse("1,2/3") // Parsed as one number '\\frac{{1,2}}{{3}}', i.e. 1.2 / 3 or 1,2 / 3
+```

--- a/asciimath-based/ASCIIMathTeXImg.js
+++ b/asciimath-based/ASCIIMathTeXImg.js
@@ -25,9 +25,24 @@ THE SOFTWARE.
 */
 
 //var AMTcgiloc = '';			//set to the URL of your LaTex renderer
-var noMathRender = false;
 
-(function() {
+// UMD export from https://github.com/umdjs/umd/blob/master/templates/returnExports.js
+// if the module has no dependencies, the above pattern can be simplified to
+(function (root, factory) {
+  if (typeof define === 'function' && define.amd) {
+      // AMD. Register as an anonymous module.
+      define([], factory);
+  } else if (typeof module === 'object' && module.exports) {
+      // Node. Does not work with strict CommonJS, but
+      // only CommonJS-like environments that support module.exports,
+      // like Node.
+      module.exports = factory();
+  } else {
+      // Browser globals (root is window)
+      root.returnExports = factory();
+}
+}(typeof self !== 'undefined' ? self : this, function () {
+
 var config = {
   translateOnLoad: true,		  //true to autotranslate
   mathcolor: "",       	      // defaults to back, or specify any other color
@@ -873,6 +888,28 @@ function AMTparseAMtoTeX(str) {
   return AMTparseExpr(str.replace(/^\s+/g,""),false)[0];
 }
 
+AMinitSymbols();
+
+return {
+  parse: AMTparseAMtoTeX,
+  config: config,
+}
+
+}));
+
+
+(function() {
+
+// Return if AMD, CommonJS or not browser
+// I.e. only run when imported using "script" tag
+if (typeof define === 'function' && define.amd) return;
+if (typeof module === 'object' && module.exports) return;
+if (typeof window === 'undefined') return; // Not browser
+
+// "Import" UMD exports. Exported as window.* later
+var AMTparseAMtoTeX = window.returnExports.parse;
+var config = window.returnExports.config;
+
 function AMparseMath(str) {
  //DLMOD to remove &nbsp;, which editor adds on multiple spaces
   str = str.replace(/(&nbsp;|\u00a0|&#160;)/g,"");
@@ -1014,8 +1051,6 @@ function translate(spanclassAM) {
 var AMbody;
 var AMtranslated = false;
 var AMnoMathML = true;
-
-AMinitSymbols();
 
 window.translate = translate;
 window.AMTconfig = config;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "asciimath",
+  "version": "1.0.0",
+  "description": "ASCIIMath parser and TeX renderer",
+  "main": "asciimath-based/ASCIIMathTeXImg.js",
+  "directories": {
+    "test": "test"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/asciimath/asciimathml.git"
+  },
+  "keywords": [
+    "ASCIIMath",
+    "LaTeX",
+    "math"
+  ],
+  "author": "David Lippman",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/asciimath/asciimathml/issues"
+  },
+  "homepage": "https://github.com/asciimath/asciimathml#readme"
+}


### PR DESCRIPTION
This would allow us to publish and import it as a webpack/nodejs package.

This makes sure anyone using the scripts can continue doing so in the same way.

Note that I am using `ASCIIMathTexImg.js` here since it converts it to Latex, as anyone using it via webpack/nodejs would likely be using/can easily use Katex/MathJax for rendering latex to HTML or MathML

The UMD export pattern does look a bit ugly to directly add to the source code but is the easiest way forward without adding a build system and refactoring the code.

Note: the `noMathRender` variable wasn't being used, so I removed it.