### PR TITLE
Remove deprecated braces for string

### DIFF
--- a/asciimath-based/ASCIIMath2TeX.php
+++ b/asciimath-based/ASCIIMath2TeX.php
@@ -356,13 +356,13 @@ function AMnewcommand($oldstr,$newstr) {
 }
 
 function AMremoveCharsAndBlanks($str,$n) {
-    	if (strlen($str)>$n+1 && $str{$n}=='\\' && $str{$n+1}!= '\\' && $str{$n+1}!=' ') {
+    	if (strlen($str)>$n+1 && $str[$n]=='\\' && $str[$n+1]!= '\\' && $str[$n+1]!=' ') {
 		$st = substr($str, $n+1);
 	} else {
 		$st = substr($str,$n);
 	}
 	$i = 0;
-	while ($i<strlen($st) && ord($st{$i})<=32) {
+	while ($i<strlen($st) && ord($st[$i])<=32) {
 		$i++;
 	}
 	return substr($st, $i);
@@ -449,12 +449,12 @@ function AMgetSymbol($str) {
 }
 
 function AMTremoveBrackets($node) {
-	if ($node{0}=='{' && $node{strlen($node)-1}=='}') {
+	if ($node[0]=='{' && $node[strlen($node)-1]=='}') {
 		
 		$leftchop = 0;
 		$st = substr($node,1,5);
 		if ($st=='\\left') {
-			$st = $node{6};
+			$st = $node[6];
 			if ($st=='(' || $st=='[' || $st=='{') {
 				$leftchop = 7;
 			} else {
@@ -464,7 +464,7 @@ function AMTremoveBrackets($node) {
 				}
 			}
 		} else {
-			$st = $node{1};
+			$st = $node[1];
 			if ($st=='(' || $st=='[') {
 				$leftchop = 2;
 			}
@@ -530,7 +530,7 @@ function AMTparseSexpr($str) {
 		$this->AMnestingDepth--;
 		$leftchop = 0;
 		if (substr($result[0],0,6)=='\\right') {
-			$st = $result[0]{6};
+			$st = $result[0][6];
 			if ($st==")" || $st=="]" || $st=="}") {
 				$leftchop = 6;
 			} else if ($st==".") {
@@ -561,19 +561,19 @@ function AMTparseSexpr($str) {
 		if ($symbol['input'] != '"') {
 			$str = $this->AMremoveCharsAndBlanks($str,strlen($symbol['input']));
 		}
-		if ($str{0}=='{') { $i = strpos($str,'}');}
-		else if ($str{0}=='(') { $i = strpos($str,')');}
-		else if ($str{0}=='[') { $i = strpos($str,']');}
+		if ($str[0]=='{') { $i = strpos($str,'}');}
+		else if ($str[0]=='(') { $i = strpos($str,')');}
+		else if ($str[0]=='[') { $i = strpos($str,']');}
 		else if ($symbol['input']=='"') {
 			$i = strpos(substr($str,1),'"')+1;
 		} else { $i = 0;}
 		if ($i==-1) { $i = strlen($str);}
 		$st = substr($str,1,$i-1);
-		if ($st{0}== " ") {
+		if ($st[0]== " ") {
 			$newFrag .= '\\ ';
 		}
 		$newFrag .= '\\text{'.$st.'}';
-		if ($st{strlen($st)-1}== " ") {
+		if ($st[strlen($st)-1]== " ") {
 			$newFrag .= '\\ ';
 		}
 		$str = $this->AMremoveCharsAndBlanks($str,$i+1);
@@ -585,7 +585,7 @@ function AMTparseSexpr($str) {
 			return array('{'.$this->AMTgetTeXsymbol($symbol).'}',$str);
 		}
 		if (isset($symbol['func'])) {
-			$st = $str{0};
+			$st = $str[0];
 			if ($st=='^' || $st=='_' || $st=='/' || $st=='|' || $st==',' || (($symbol['input']=='f' || $symbol['input']=='g')  && $st!='(')) {
 				return array('{'.$this->AMTgetTeXsymbol($symbol).'}',$str);
 			} else {
@@ -638,7 +638,7 @@ function AMTparseSexpr($str) {
 		$str = $this->AMremoveCharsAndBlanks($str,strlen($symbol['input']));
 		$result = $this->AMTparseExpr($str,false);
 		$this->AMnestingDepth--;
-		$st = $result[0]{strlen($result[0])-1};
+		$st = $result[0][strlen($result[0])-1];
 		if ($st == '|') {
 			$node = '{\\left|'.$result[0].'}';
 			return array($node,$result[1]);
@@ -649,7 +649,7 @@ function AMTparseSexpr($str) {
 	} else {
 		$str = $this->AMremoveCharsAndBlanks($str,strlen($symbol['input']));
 		$texsymbol = $this->AMTgetTeXsymbol($symbol);
-		if ($texsymbol{0}=='\\' || (isset($symbol['isop']) && $symbol['isop']==true)) {
+		if ($texsymbol[0]=='\\' || (isset($symbol['isop']) && $symbol['isop']==true)) {
 			return array($texsymbol,$str);
 		} else {
 			return array('{'.$texsymbol.'}',$str);
@@ -736,10 +736,10 @@ function AMTparseExpr($str,$rightbracket) {
 	} while ((!isset($symbol['rightbracket']) && (!isset($symbol['leftright']) || $rightbracket) || $this->AMnestingDepth==0) && $symbol!=null && $symbol['input']!='');
 	if (isset($symbol['rightbracket']) || isset($symbol['leftright'])) {
 		$len = strlen($newFrag);
-		if ($len>2 && $newFrag{0}=='{' && strpos($newFrag,',')>0) {
-			$right = $newFrag{$len-2};
+		if ($len>2 && $newFrag[0]=='{' && strpos($newFrag,',')>0) {
+			$right = $newFrag[$len-2];
 			if ($right==')' || $right==']') {
-				$left = $newFrag{6};
+				$left = $newFrag[6];
 				if (($left=='(' && $right==')' && $symbol['input']!='}') || ($left=='[' && $right==']')) {
 					$mxout = '';
 					$pos = array();
@@ -754,10 +754,10 @@ function AMTparseExpr($str,$rightbracket) {
 					$addedlast = true;
 					$newFragLen = strlen($newFrag);
 					for ($i=1; $i<$len-1;$i++) {
-						if ($newFrag{$i}==$left) { $mxnestingd++;}
-						if ($newFrag{$i}==$right) {
+						if ($newFrag[$i]==$left) { $mxnestingd++;}
+						if ($newFrag[$i]==$right) {
 							$mxnestingd--;
-							if ($mxnestingd==0 && $newFragLen>$i+3 && $newFrag{$i+2}==',' && $newFrag{$i+3}=='{') {
+							if ($mxnestingd==0 && $newFragLen>$i+3 && $newFrag[$i+2]==',' && $newFrag[$i+3]=='{') {
 								array_push($pos,$i+2);
 								$lastsubposstart= $i+2;
 								$subpos[$lastsubposstart] = array($i+2);
@@ -765,9 +765,9 @@ function AMTparseExpr($str,$rightbracket) {
 								$matrix = false;
 							}
 						}
-						if ($newFrag{$i}=='[' || $newFrag{$i}=='(' || $newFrag{$i}=='{') {$mxanynestingd++;}
-						if ($newFrag{$i}==']' || $newFrag{$i}==')' || $newFrag{$i}=='}') {$mxanynestingd--;}
-						if ($newFrag{$i}==',' && $mxanynestingd==1) {
+						if ($newFrag[$i]=='[' || $newFrag[$i]=='(' || $newFrag[$i]=='{') {$mxanynestingd++;}
+						if ($newFrag[$i]==']' || $newFrag[$i]==')' || $newFrag[$i]=='}') {$mxanynestingd--;}
+						if ($newFrag[$i]==',' && $mxanynestingd==1) {
 							$subpos[$lastsubposstart][] = $i;
 						}
 						if ($mxanynestingd<0) {  //happens at the end of the row


### PR DESCRIPTION
Hello, sorry for my English.
I am trying this script on **PHP 7.4** and it's has some deprecation.
This pull request update **braces** and replace it **to square brackets**.