### PR TITLE
Add mspace unary

### DIFF
--- a/ASCIIMathML.js
+++ b/ASCIIMathML.js
@@ -418,7 +418,7 @@ var AMsymbols = [
 {input:"qquad", tag:"mspace", output:"2", tex:null, ttype:CONST},
 {input:"enspace", tag:"mspace", output:"0.5", tex:null, ttype:CONST},
 {input:"thinspace", tag:"mspace", output:"0.17", tex:null, ttype:CONST},
-{input:"mspace", tag:"mspace", output:"mspace", tex:null, ttype:UNARY},
+{input:"mspace", tag:"mspace", output:"mspace", tex:null, ttype:TEXT},
 {input:"cdots", tag:"mo", output:"\u22EF", tex:null, ttype:CONST},
 {input:"vdots", tag:"mo", output:"\u22EE", tex:null, ttype:CONST},
 {input:"ddots", tag:"mo", output:"\u22F1", tex:null, ttype:CONST},
@@ -747,6 +747,18 @@ function AMparseSexpr(str) { //parses str and returns [node,tailstr]
       else i = 0;
       if (i==-1) i = str.length;
       st = str.slice(1,i);
+      if (symbol.input === 'mspace') { // special case
+        var m = st.match(/^(-?[\d\.]+)\s*(em|mu)?$/);
+        if (!m) {
+          st = "0em";
+        } else if (!m[2] || m[2] == "mu") {
+          st = (m[1]/16) + "em";
+        }
+        node = createMmlNode(symbol.tag);
+        node.setAttribute("width", st);
+        str = AMremoveCharsAndBlanks(str,i+1);
+        return [node, str];
+      }
       if (st.charAt(0) == " ") {
         node = createMmlNode("mspace");
         node.setAttribute("width","1ex");
@@ -795,17 +807,6 @@ function AMparseSexpr(str) { //parses str and returns [node,tailstr]
           node.appendChild(result[0]);
           node.appendChild(createMmlNode("mo",document.createTextNode(symbol.rewriteleftright[1])));
           return [node,result[1]];
-      } else if (symbol.input == "mspace") {
-        st = result[0].textContent;
-        var m = st.match(/^(-?[\d\.]+)\s*(em|\u03BC)?$/);
-        if (!m) {
-          st = "0em";
-        } else if (!m[2] || m[2] == "\u03BC") {
-          st = (m[1]/16) + "em";
-        }
-        node = createMmlNode(symbol.tag);
-        node.setAttribute("width", st);
-        return [node, result[1]];
       } else if (symbol.input == "cancel") {   // cancel
         node = createMmlNode(symbol.tag,result[0]);
 	node.setAttribute("notation","updiagonalstrike");

--- a/ASCIIMathML.js
+++ b/ASCIIMathML.js
@@ -418,6 +418,7 @@ var AMsymbols = [
 {input:"qquad", tag:"mspace", output:"2", tex:null, ttype:CONST},
 {input:"enspace", tag:"mspace", output:"0.5", tex:null, ttype:CONST},
 {input:"thinspace", tag:"mspace", output:"0.17", tex:null, ttype:CONST},
+{input:"mspace", tag:"mspace", output:"mspace", tex:null, ttype:UNARY},
 {input:"cdots", tag:"mo", output:"\u22EF", tex:null, ttype:CONST},
 {input:"vdots", tag:"mo", output:"\u22EE", tex:null, ttype:CONST},
 {input:"ddots", tag:"mo", output:"\u22F1", tex:null, ttype:CONST},
@@ -794,6 +795,16 @@ function AMparseSexpr(str) { //parses str and returns [node,tailstr]
           node.appendChild(result[0]);
           node.appendChild(createMmlNode("mo",document.createTextNode(symbol.rewriteleftright[1])));
           return [node,result[1]];
+      } else if (symbol.input == "mspace") {
+        st = result[0].textContent;
+        if (st.match(/^-?[\d\.]+$/)) {
+          st += "em";
+        } else if (!st.match(/^-?[\d\.]+\s*[a-z]{2}$/)) {
+          st = "0em";
+        }
+        node = createMmlNode(symbol.tag);
+        node.setAttribute("width", st);
+        return [node, result[1]];
       } else if (symbol.input == "cancel") {   // cancel
         node = createMmlNode(symbol.tag,result[0]);
 	node.setAttribute("notation","updiagonalstrike");

--- a/ASCIIMathML.js
+++ b/ASCIIMathML.js
@@ -797,10 +797,11 @@ function AMparseSexpr(str) { //parses str and returns [node,tailstr]
           return [node,result[1]];
       } else if (symbol.input == "mspace") {
         st = result[0].textContent;
-        if (st.match(/^-?[\d\.]+$/)) {
-          st += "em";
-        } else if (!st.match(/^-?[\d\.]+\s*[a-z]{2}$/)) {
+        var m = st.match(/^(-?[\d\.]+)\s*(em|\u03BC)?$/);
+        if (!m) {
           st = "0em";
+        } else if (!m[2] || m[2] == "\u03BC") {
+          st = (m[1]/16) + "em";
         }
         node = createMmlNode(symbol.tag);
         node.setAttribute("width", st);

--- a/ASCIIMathML.js
+++ b/ASCIIMathML.js
@@ -751,8 +751,8 @@ function AMparseSexpr(str) { //parses str and returns [node,tailstr]
         var m = st.match(/^(-?[\d\.]+)\s*(em|mu)?$/);
         if (!m) {
           st = "0em";
-        } else if (!m[2] || m[2] == "mu") {
-          st = (m[1]/16) + "em";
+        } else if ((!m[2] || m[2] === "mu") && !isNaN(parseFloat(m[1]))) {
+          st = (parseFloat(m[1])/16) + "em";
         }
         node = createMmlNode(symbol.tag);
         node.setAttribute("width", st);

--- a/ASCIIMathML.js
+++ b/ASCIIMathML.js
@@ -10,7 +10,7 @@ Just add the next line to your HTML page with this file in the same folder:
 
 <script type="text/javascript" src="ASCIIMathML.js"></script>
 
-Version 2.5 May 18 2026.
+Version 2.5.1 May 20 2026.
 Latest version at https://github.com/asciimath/asciimathml
 If you use it on a webpage, please send the URL to jipsen@chapman.edu
 

--- a/asciimath-based/ASCIIMath2TeX.php
+++ b/asciimath-based/ASCIIMath2TeX.php
@@ -193,6 +193,7 @@ array( 'input'=>'quad'),
 array( 'input'=>'qquad'),
 array( 'input'=>'enspace'),
 array( 'input'=>'thinspace'),
+array( 'input'=>'mspace', 'text'=>TRUE),
 array( 'input'=>'cdots'),
 array( 'input'=>'vdots'), 
 array( 'input'=>'ddots'), 
@@ -605,6 +606,18 @@ function AMTparseSexpr($str) {
 		} else { $i = 0;}
 		if ($i==-1) { $i = strlen($str);}
 		$st = substr($str,1,$i-1);
+		$newFrag = '';
+		if ($symbol['input'] === 'mspace') { // special case
+			if (preg_match('/^(-?[\d\.]+)\s*(em|mu)?$/', $st, $m)) {
+				if ((empty($m[2]) || $m[2] === "mu") && is_numeric($m[1])) {
+					$newFrag = "\\mspace{" . floatval($m[1]) . "mu}";
+				} else if (!empty($m[2]) && $m[2] === "em" && is_numeric($m[1])) {
+					$newFrag = "\\mspace{" . (floatval($m[1])*16) . "mu}";
+				}
+			}
+			$str = $this->AMremoveCharsAndBlanks($str,$i+1);
+			return array($newFrag, $str);
+		}
 		if (strlen($st)>0 && $st[0]== " ") {
 			$newFrag .= '\\ ';
 		}

--- a/asciimath-based/ASCIIMath2TeX.php
+++ b/asciimath-based/ASCIIMath2TeX.php
@@ -9,7 +9,7 @@ Use:
 	$tex = $AMT->convert($AMstring); //convert ASCIIMath string to TeX
 	
 Based on ASCIIMathML, Version 1.4.7 Aug 30, 2005, (c) Peter Jipsen http://www.chapman.edu/~jipsen
-  updated to match Version 2.5 May 18 2026.
+  updated to match Version 2.5.1 May 20 2026.
   
 This is a PHP port of a Javascript modification of ASCIIMathML
 Modified with TeX conversion for IMG rendering 

--- a/asciimath-based/ASCIIMathTeXImg.js
+++ b/asciimath-based/ASCIIMathTeXImg.js
@@ -233,6 +233,7 @@ var AMsymbols = [
 {input:"qquad", tag:"mo", output:"\u00A0\u00A0\u00A0\u00A0", tex:null, ttype:CONST},
 {input:"enspace", tag:"mo", output:" ", tex:null, ttype:CONST},
 {input:"thinspace", tag:"mo", output:" ", tex:null, ttype:CONST},
+{input:"mspace", tag:"mspace", output:"mspace", tex:null, ttype:TEXT},
 {input:"cdots", tag:"mo", output:"\u22EF", tex:null, ttype:CONST},
 {input:"vdots", tag:"mo", output:"\u22EE", tex:null, ttype:CONST},
 {input:"ddots", tag:"mo", output:"\u22F1", tex:null, ttype:CONST},
@@ -621,6 +622,19 @@ function AMTparseSexpr(str) { //parses str and returns [node,tailstr]
       else i = 0;
       if (i==-1) i = str.length;
       st = str.slice(1,i);
+      if (symbol.input === 'mspace') { // special case
+        var m = st.match(/^(-?[\d\.]+)\s*(em|mu)?$/);
+        newFrag = '';
+        if (m) {
+          if ((!m[2] || m[2] === "mu") && !isNaN(parseFloat(m[1]))) {
+            newFrag = "\\mspace{"+parseFloat(m[1])+ "mu}";
+          } else if (m[2] === "em" && !isNaN(parseFloat(m[1]))) {
+            newFrag = "\\mspace{"+(parseFloat(m[1])*16)+ "mu}";
+          }
+        }
+        str = AMremoveCharsAndBlanks(str,i+1);
+        return [newFrag, str];
+      }
       if (st.charAt(0) == " ") {
 	      newFrag = '\\ ';
       }

--- a/asciimath-based/ASCIIMathTeXImg.js
+++ b/asciimath-based/ASCIIMathTeXImg.js
@@ -2,7 +2,7 @@
 ASCIIMathTeXImg.js
 Based on ASCIIMathML, Version 1.4.7 Aug 30, 2005, (c) Peter Jipsen http://www.chapman.edu/~jipsen
 Modified with TeX conversion for IMG rendering Sept 6, 2006 (c) David Lippman http://www.pierce.ctc.edu/dlippman
-  Updated to match Version 2.5 May 18 2026.
+  Updated to match Version 2.5.1 May 20 2026.
   Latest at https://github.com/mathjax/asciimathml
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/asciimath-based/amimgtest.html
+++ b/asciimath-based/amimgtest.html
@@ -328,6 +328,10 @@ Miscellaneous
 
 <tr><td>RR</td><td>`RR`</td></tr>
 <tr><td>ZZ</td><td>`ZZ`</td></tr>
+<tr><td>a thinspace b</td><td>`a thinspace b`</td></tr>
+<tr><td>a mspace(8) b</td><td>`a mspace(8) b`</td></tr>
+<tr><td>a mspace(8mu) b</td><td>`a mspace(8mu) b`</td></tr>
+<tr><td>a mspace(0.3em) b</td><td>`a mspace(0.3em) b`</td></tr>
 </table>
 </td><td style="border:0px;">
 Functions

--- a/test/unittests.js
+++ b/test/unittests.js
@@ -534,6 +534,15 @@ var unittests = [
 {input: "2^+3", output:"<msup><mn>2</mn><mo>+</mo></msup><mn>3</mn>"},
 {input: "/4", output:"<mo>/</mo><mn>4</mn>"},
 {input: "lim_(x rarr 2^-) f(x)", output:"<munder><mo>lim</mo><mrow><mi>x</mi><mo>→</mo><msup><mn>2</mn><mo>−</mo></msup></mrow></munder><mrow><mi>f</mi><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow>"},
+
+// pr 165
+{input: "a mspace(8)b", output:"<mi>a</mi><mspace width=\"0.5em\"></mspace><mi>b</mi>"}, // no units treated as mu
+{input: "a mspace(8mu) b", output:"<mi>a</mi><mspace width=\"0.5em\"></mspace><mi>b</mi>"}, //mu ok
+{input: "a mspace(8 mu) b", output:"<mi>a</mi><mspace width=\"0.5em\"></mspace><mi>b</mi>"}, //space between number and units ok
+{input: "a mspace{0.3em} b", output:"<mi>a</mi><mspace width=\"0.3em\"></mspace><mi>b</mi>"}, // braces ok, em units ok
+{input: "a mspace(0.3ch) b", output:"<mi>a</mi><mspace width=\"0em\"></mspace><mi>b</mi>"}, // ch not supported; produces 0 width
+{input: "a mspace(-0.2em) b", output:"<mi>a</mi><mspace width=\"-0.2em\"></mspace><mi>b</mi>"}, // negative decimal ok, though browser may not support
+{input: "a mspace3 b", output:"<mi>a</mi><mspace width=\"0em\"></mspace><mi>b</mi>"}, // braces/parens required
 ];
 
 function htmlEntities(str) {


### PR DESCRIPTION
Allows for creating arbitrary spaces.  Supports single numbers (treated as mu units), number with mu units, and number with em units, like

`mspace(5), mspace(5mu), mspace(2em)`

As suggested in #162 discussion